### PR TITLE
Extract mysql-status cmd to script

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -131,7 +131,7 @@ k8s_resource('mysql-router-simple',
 
 # MySQL helper commands
 local_resource('mysql-status',
-  cmd='kubectl exec -n db mysql-0 -- mysql -u root -p$(./scripts/get-mysql-password.sh) -e "SHOW VARIABLES LIKE \'hostname\'; SHOW STATUS LIKE \'Uptime\';"',
+  cmd='./scripts/mysql-status.sh',
   labels=['mysql-ops'],
   resource_deps=['mysql']
 )

--- a/scripts/mysql-status.sh
+++ b/scripts/mysql-status.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# MySQL Status Check Script
+# Shows hostname and uptime for MySQL instance
+
+set -e
+
+# Get MySQL root password
+MYSQL_PASSWORD=$(./scripts/get-mysql-password.sh)
+
+# Execute MySQL status commands
+kubectl exec -n db mysql-0 -- mysql -u root -p"${MYSQL_PASSWORD}" -e "SHOW VARIABLES LIKE 'hostname'; SHOW STATUS LIKE 'Uptime';"


### PR DESCRIPTION
Extract `mysql-status` command from Tiltfile into a dedicated script for better organization and reusability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d285dca8-bb5d-4514-b4f5-35acc055edce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d285dca8-bb5d-4514-b4f5-35acc055edce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>